### PR TITLE
feat(cmake): add shared/static build option and improve install & pac…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,12 @@ target_link_libraries(slave_cpp ${LINK_LIBS})
 add_executable(master_cpp ${MASTER_APP_CPP_SRC})
 target_link_libraries(master_cpp ${LINK_LIBS})
 
+add_executable(sdo_read ${CMAKE_CURRENT_SOURCE_DIR}/examples/tools/sdo_read.c ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/gendcf.c ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/masterdic.c)
+target_link_libraries(sdo_read ${LINK_LIBS})
+
+add_executable(sdo_write ${CMAKE_CURRENT_SOURCE_DIR}/examples/tools/sdo_write.c ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/gendcf.c ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/masterdic.c)
+target_link_libraries(sdo_write ${LINK_LIBS})
+
 
 # ----------------------------------------------------------------------------
 # Install settings (use -DCMAKE_INSTALL_PREFIX=/your/prefix when configuring)
@@ -92,6 +98,8 @@ install(TARGETS
     slave
     master_cpp
     slave_cpp
+  sdo_read
+  sdo_write
     EXPORT CanFestivalTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}      # 静态库 (.a)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}      # 共享库 (若改成 SHARED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
 
+project(canfestival VERSION 1.0.0)
 
-project(canfestival)
+option(CANFESTIVAL_BUILD_SHARED "Build CanFestival as shared libraries" ON)
+if(CANFESTIVAL_BUILD_SHARED)
+  set(CANFESTIVAL_LIB_TYPE SHARED)
+else()
+  set(CANFESTIVAL_LIB_TYPE STATIC)
+endif()
 
 include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/unix/
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/timers_unix/
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/
-)
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/unix/
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/timers_unix/
+  ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/)
 
 # add_compile_options(-fPIC -Wall -g -Wmissing-prototypes -fno-strict-aliasing)
 add_compile_options(-fPIC -Wall -g -fno-strict-aliasing)
@@ -18,81 +23,110 @@ add_compile_definitions(NOT_USE_DYNAMIC_LOADING CO_ENABLE_LSS CO_ENABLE_LSS_FS)
 add_compile_definitions(DEBUG_ERR_CONSOLE_ON)
 # add_compile_definitions(DEBUG_WAR_CONSOLE_ON)
 
-set(CANFESTIVAL_SRC 
+set(CANFESTIVAL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/dcf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/emcy.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/lifegrd.c
-
     ${CMAKE_CURRENT_SOURCE_DIR}/src/lss.c
-
     ${CMAKE_CURRENT_SOURCE_DIR}/src/nmtMaster.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/nmtSlave.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/objacces.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sdo.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pdo.c
-    
     ${CMAKE_CURRENT_SOURCE_DIR}/src/states.c
-
     # ${CMAKE_CURRENT_SOURCE_DIR}/src/symbols.c
-
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sync.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/timer.c
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/timer.c)
 
 set(CANFESTIVAL_DRV_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/can_socket/can_socket.c
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/timers_unix/timers_linux.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/drivers/unix/unix.c
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}/drivers/unix/unix.c)
 
-
-
-set(SLAVE_APP_C_SRC 
+set(SLAVE_APP_C_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/slave.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/slavedic.c
-    
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/slavedic.c)
 
-set(MASTER_APP_C_SRC 
+set(MASTER_APP_C_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/master.c
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/gendcf.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/masterdic.c
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/masterdic.c)
 
-set(SLAVE_APP_CPP_SRC 
+set(SLAVE_APP_CPP_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/slave.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/slavedic.c
-    
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/slavedic.c)
 
-set(MASTER_APP_CPP_SRC 
+set(MASTER_APP_CPP_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/master.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/gendcf.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/masterdic.c
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/masterdic.c)
 
+add_library(canfestival ${CANFESTIVAL_LIB_TYPE} ${CANFESTIVAL_SRC})
+add_library(canfestival_can_socket ${CANFESTIVAL_LIB_TYPE} ${CANFESTIVAL_DRV_SRC})
 
-add_library(canfestival STATIC ${CANFESTIVAL_SRC})
-add_library(canfestival_can_socket STATIC ${CANFESTIVAL_DRV_SRC})
+set(LINK_LIBS canfestival canfestival_can_socket pthread dl rt)
 
-
-set(LINK_LIBS 
-    canfestival
-    canfestival_can_socket
-    pthread
-    dl
-    rt
-)
-
-add_executable(slave ${SLAVE_APP_C_SRC} )
+add_executable(slave ${SLAVE_APP_C_SRC})
 target_link_libraries(slave ${LINK_LIBS})
 
-add_executable(master ${MASTER_APP_C_SRC} )
+add_executable(master ${MASTER_APP_C_SRC})
 target_link_libraries(master ${LINK_LIBS})
 
-
-add_executable(slave_cpp ${SLAVE_APP_CPP_SRC} )
+add_executable(slave_cpp ${SLAVE_APP_CPP_SRC})
 target_link_libraries(slave_cpp ${LINK_LIBS})
 
-add_executable(master_cpp ${MASTER_APP_CPP_SRC} )
+add_executable(master_cpp ${MASTER_APP_CPP_SRC})
 target_link_libraries(master_cpp ${LINK_LIBS})
+
+
+# ----------------------------------------------------------------------------
+# Install settings (use -DCMAKE_INSTALL_PREFIX=/your/prefix when configuring)
+# ----------------------------------------------------------------------------
+include(GNUInstallDirs)
+
+# 需要安装的目标（库 + 可执行文件）
+install(TARGETS
+    canfestival
+    canfestival_can_socket
+    master
+    slave
+    master_cpp
+    slave_cpp
+    EXPORT CanFestivalTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}      # 静态库 (.a)
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}      # 共享库 (若改成 SHARED)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})     # 可执行文件
+
+# 安装公共头文件
+install(DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h")
+
+# 安装生成/手写的 OD 相关头文件（若需要对外使用）
+install(DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/linux/dcf/od/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/canfestival/od
+    FILES_MATCHING PATTERN "*.h")
+
+# 生成并安装配置文件
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/CanFestivalConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CanFestivalConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/CanFestivalConfig.cmake
+  @ONLY)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/CanFestivalConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/CanFestivalConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CanFestival)
+
+install(EXPORT CanFestivalTargets
+  NAMESPACE CanFestival::
+  FILE CanFestivalTargets.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CanFestival)

--- a/cmake/CanFestivalConfig.cmake.in
+++ b/cmake/CanFestivalConfig.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+# 可选: 暴露一个包含目录变量
+set(CANFESTIVAL_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include")
+
+include("${CMAKE_CURRENT_LIST_DIR}/CanFestivalTargets.cmake")

--- a/examples/tools/README.md
+++ b/examples/tools/README.md
@@ -1,0 +1,49 @@
+# CanFestival Tools (sdo_read / sdo_write)
+
+Small CLI tools to read and write CANopen SDOs using CanFestival + SocketCAN.
+
+## Build
+
+- cmake -S . -B build
+- cmake --build build -j
+
+Executables: `build/sdo_read`, `build/sdo_write`.
+
+## sdo_read
+
+Usage:
+
+- sdo_read <can-if> <nodeId> <index-hex> <subidx-hex> [type]
+- type: u8|u16|u32|i8|i16|i32|domain (default u32)
+
+Examples:
+
+- ./build/sdo_read can0 1 1000 00 u32   # 读取 0x1000:00 设备类型
+- ./build/sdo_read can0 1 1018 01 u32   # 读取 VendorId
+- ./build/sdo_read can0 1 1017 00 u16   # 读取心跳时间
+
+Notes:
+- 工具会动态配置主站的 SDO Client (0x1280) 指向目标节点 (0x600+ID / 0x580+ID)，并向目标发送 NMT Start。
+- 对于 domain 类型，会显示长度与前若干字节的十六进制内容。
+
+## sdo_write
+
+Usage:
+
+- sdo_write <can-if> <nodeId> <index-hex> <subidx-hex> <type> <value>
+- type: u8|u16|u32|i8|i16|i32
+- value: 十进制或 0x 前缀十六进制
+
+Examples:
+
+- ./build/sdo_write can0 1 1017 00 u16 1000   # 写入心跳时间 1000ms
+- ./build/sdo_write can0 1 2000 01 u8 0x12    # 写入 0x2000:01 = 0x12
+- ./build/sdo_write can0 1 3000 02 u32 0x1F4  # 写入 0x1F4
+
+Notes:
+- 某些对象需要通过 0x1010 存储或重置通信才能生效，参考设备手册。
+
+## Troubleshooting
+
+- 超时：检查 can0 速率与接口已启用；用 candump 观察 0x600/0x580 报文是否往返。
+- SDO Abort：工具会打印 32 位 AbortCode，请查阅 CiA 301 对应含义。

--- a/examples/tools/sdo_read.c
+++ b/examples/tools/sdo_read.c
@@ -1,0 +1,170 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdbool.h>
+
+#include "canfestival.h"
+#include "masterdic.h" // reuse generated OD for types and CO_Data
+#include "objdictdef.h" // data type codes (uint8/uint16/...)
+#include "objacces.h"   // writeLocalDict
+
+static volatile int g_run = 1;
+static void on_sigint(int sig){ (void)sig; g_run = 0; }
+
+static void usage(const char* prog){
+    fprintf(stderr, "Usage: %s <can-if> <nodeId> <index-hex> <subidx-hex> [type]\n", prog);
+    fprintf(stderr, "  type: u8|u16|u32|i8|i16|i32|domain (default u32)\n");
+}
+
+static UNS8 parse_type(const char* s){
+    if(!s) return uint32;
+    if(!strcmp(s, "u8")) return uint8;
+    if(!strcmp(s, "u16")) return uint16;
+    if(!strcmp(s, "u32")) return uint32;
+    if(!strcmp(s, "i8")) return int8;
+    if(!strcmp(s, "i16")) return int16;
+    if(!strcmp(s, "i32")) return int32;
+    if(!strcmp(s, "domain")) return domain;
+    return uint32;
+}
+
+static void post_SlaveStateChange(CO_Data* d, UNS8 nodeId, e_nodeState newState){
+    (void)d;
+    const char* name = "Unknown";
+    switch(newState){
+        case Initialisation:  name = "Initialisation"; break;
+        case Disconnected:    name = "Disconnected";  break;
+        case Connecting:      name = "Connecting/Preparing";    break; /* Preparing has same value */
+        case Stopped:         name = "Stopped";       break;
+        case Operational:     name = "Operational";   break;
+        case Pre_operational: name = "Pre_operational"; break;
+        case Unknown_state:   name = "Unknown_state"; break;
+        default: break;
+    }
+    printf("Node %u -> %s\n", nodeId, name);
+}
+
+int main(int argc, char** argv){
+    if(argc < 5){ usage(argv[0]); return 1; }
+    const char* ifname = argv[1];
+    int nodeId = (int)strtol(argv[2], NULL, 0);
+    UNS16 index = (UNS16)strtol(argv[3], NULL, 16);
+    UNS8 sub = (UNS8)strtol(argv[4], NULL, 16);
+    UNS8 dtype = parse_type(argc > 5 ? argv[5] : NULL);
+
+    s_BOARD board = {0};
+    board.busname = (char*)ifname;
+    board.baudrate = ""; // use pre-configured bitrate on interface
+
+    // Prepare minimal CO_Data using masterdic_Data from example
+    extern CO_Data masterdic_Data;
+    CO_Data* d = &masterdic_Data;
+
+    // Install minimal callbacks
+    d->post_SlaveStateChange = post_SlaveStateChange;
+
+    if(!canOpen(&board, d)){
+        fprintf(stderr, "Cannot open CAN interface %s\n", ifname);
+        return 2;
+    }
+
+    signal(SIGINT, on_sigint);
+
+    // Start timers (for timeouts) and set node state
+    TimerInit();
+    // Put master into Pre-operational and then Operational
+    setNodeId(d, 100);
+    setState(d, Pre_operational);
+    setState(d, Operational);
+
+    printf("Reading SDO 0x%04X:%02X from node %d on %s (type=%d)\n", index, sub, nodeId, ifname, (int)dtype);
+
+    // Configure SDO client (0x1280) to address the requested nodeId
+    {
+        UNS8 nodeU8 = (UNS8)nodeId;
+        UNS32 cob_tx = 0x600 + (UNS32)nodeU8; // client->server
+        UNS32 cob_rx = 0x580 + (UNS32)nodeU8; // server->client
+        UNS32 sz32 = sizeof(UNS32);
+        UNS32 sz8  = sizeof(UNS8);
+        if (writeLocalDict(d, 0x1280, 1, &cob_tx, &sz32, RW) != OD_SUCCESSFUL)
+            fprintf(stderr, "Warn: failed to set 0x1280:1 (TX COB-ID)\n");
+        if (writeLocalDict(d, 0x1280, 2, &cob_rx, &sz32, RW) != OD_SUCCESSFUL)
+            fprintf(stderr, "Warn: failed to set 0x1280:2 (RX COB-ID)\n");
+        if (writeLocalDict(d, 0x1280, 3, &nodeU8, &sz8, RW) != OD_SUCCESSFUL)
+            fprintf(stderr, "Warn: failed to set 0x1280:3 (Server NodeID)\n");
+    }
+
+    // Ensure target node is started
+    masterSendNMTstateChange(d, (UNS8)nodeId, NMT_Start_Node);
+
+    // Initiate SDO read
+    UNS8 ret = readNetworkDict(d, (UNS8)nodeId, index, sub, dtype, 0);
+    if(ret){
+        fprintf(stderr, "readNetworkDict failed: 0x%02X\n", ret);
+        canClose(d);
+        return 3;
+    }
+
+    // Poll for result
+    int loops = 0;
+    union { UNS8 u8; UNS16 u16; UNS32 u32; INTEGER8 i8; INTEGER16 i16; INTEGER32 i32; } val;
+    memset(&val, 0, sizeof(val));
+    unsigned char domainBuf[512];
+    while(g_run){
+        UNS32 size;
+        switch(dtype){
+            case uint8:
+            case int8:   size = 1; break;
+            case uint16:
+            case int16:  size = 2; break;
+            case uint32:
+            case int32:  size = 4; break;
+            case domain: size = sizeof(domainBuf); break;
+            default:     size = sizeof(val); break;
+        }
+        void* dataPtr = (dtype == domain) ? (void*)domainBuf : (void*)&val;
+        UNS32 abortCode = 0;
+
+        UNS8 st = getReadResultNetworkDict(d, (UNS8)nodeId, dataPtr, &size, &abortCode);
+        if(st == SDO_FINISHED){
+            switch(dtype){
+                case uint8:  printf("Value: 0x%02X (u8=%u)\n",  val.u8, (unsigned)val.u8); break;
+                case uint16: printf("Value: 0x%04X (u16=%u)\n", (unsigned)val.u16, (unsigned)val.u16); break;
+                case uint32: printf("Value: 0x%08X (u32=%u)\n", (unsigned)val.u32, (unsigned)val.u32); break;
+                case int8:   printf("Value: 0x%02X (i8=%d)\n",  (unsigned)(UNS8)val.i8,  (int)val.i8); break;
+                case int16:  printf("Value: 0x%04X (i16=%d)\n", (unsigned)(UNS16)val.i16, (int)val.i16); break;
+                case int32:  printf("Value: 0x%08X (i32=%d)\n", (unsigned)val.i32, (int)val.i32); break;
+                case domain: {
+                    printf("Value: <domain> size=%u\n", (unsigned)size);
+                    unsigned toShow = size < 32 ? size : 32;
+                    printf("  data:");
+                    for(unsigned i=0;i<toShow;i++) printf(" %02X", domainBuf[i]);
+                    if(size>toShow) printf(" ...");
+                    printf("\n");
+                    break;
+                }
+                default:     printf("Value: <unknown type>\n"); break;
+            }
+            break;
+        } else if(st == SDO_ABORTED_RCV || st == SDO_ABORTED_INTERNAL){
+            fprintf(stderr, "SDO aborted (st=0x%02X): 0x%08X\n", st, (unsigned)abortCode);
+            canClose(d);
+            return 4;
+        } else if (st == SDO_PROVIDED_BUFFER_TOO_SMALL) {
+            fprintf(stderr, "Provided buffer too small (need %u+)\n", (unsigned)size);
+            canClose(d);
+            return 6;
+        }
+        usleep(1000 * 10);
+    if(++loops > 1000){
+            fprintf(stderr, "Timeout waiting SDO response\n");
+            canClose(d);
+            return 5;
+        }
+    }
+
+    canClose(d);
+    return 0;
+}

--- a/examples/tools/sdo_write.c
+++ b/examples/tools/sdo_write.c
@@ -1,0 +1,170 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdbool.h>
+
+#include "canfestival.h"
+#include "masterdic.h"
+#include "objdictdef.h"
+#include "objacces.h"
+
+static volatile int g_run = 1;
+static void on_sigint(int sig){ (void)sig; g_run = 0; }
+
+static void usage(const char* prog){
+    fprintf(stderr, "Usage: %s <can-if> <nodeId> <index-hex> <subidx-hex> <type> <value>\n", prog);
+    fprintf(stderr, "  type: u8|u16|u32|i8|i16|i32\n");
+    fprintf(stderr, "  value: decimal or 0x-prefixed hex\n");
+}
+
+static UNS8 parse_type(const char* s){
+    if(!s) return 0;
+    if(!strcmp(s, "u8")) return uint8;
+    if(!strcmp(s, "u16")) return uint16;
+    if(!strcmp(s, "u32")) return uint32;
+    if(!strcmp(s, "i8")) return int8;
+    if(!strcmp(s, "i16")) return int16;
+    if(!strcmp(s, "i32")) return int32;
+    return 0;
+}
+
+static unsigned size_of_type(UNS8 t){
+    switch(t){
+        case uint8: case int8: return 1;
+        case uint16: case int16: return 2;
+        case uint32: case int32: return 4;
+        default: return 0;
+    }
+}
+
+static void post_SlaveStateChange(CO_Data* d, UNS8 nodeId, e_nodeState newState){
+    (void)d;
+    const char* name = "Unknown";
+    switch(newState){
+        case Initialisation:  name = "Initialisation"; break;
+        case Disconnected:    name = "Disconnected";  break;
+        case Connecting:      name = "Connecting/Preparing";    break;
+        case Stopped:         name = "Stopped";       break;
+        case Operational:     name = "Operational";   break;
+        case Pre_operational: name = "Pre_operational"; break;
+        case Unknown_state:   name = "Unknown_state"; break;
+        default: break;
+    }
+    printf("Node %u -> %s\n", nodeId, name);
+}
+
+int main(int argc, char** argv){
+    if(argc < 7){ usage(argv[0]); return 1; }
+    const char* ifname = argv[1];
+    int nodeId = (int)strtol(argv[2], NULL, 0);
+    UNS16 index = (UNS16)strtol(argv[3], NULL, 16);
+    UNS8 sub = (UNS8)strtol(argv[4], NULL, 16);
+    UNS8 dtype = parse_type(argv[5]);
+    const char* valStr = argv[6];
+    if(dtype == 0){ fprintf(stderr, "Unknown type: %s\n", argv[5]); usage(argv[0]); return 1; }
+
+    // Parse value (hex or dec)
+    long long sval = 0;
+    if(strncmp(valStr, "0x", 2) == 0 || strncmp(valStr, "0X", 2) == 0)
+        sval = strtoll(valStr, NULL, 16);
+    else
+        sval = strtoll(valStr, NULL, 0);
+
+    s_BOARD board = {0};
+    board.busname = (char*)ifname;
+    board.baudrate = "";
+
+    extern CO_Data masterdic_Data;
+    CO_Data* d = &masterdic_Data;
+    d->post_SlaveStateChange = post_SlaveStateChange;
+
+    if(!canOpen(&board, d)){
+        fprintf(stderr, "Cannot open CAN interface %s\n", ifname);
+        return 2;
+    }
+
+    signal(SIGINT, on_sigint);
+
+    TimerInit();
+    setNodeId(d, 100);
+    setState(d, Pre_operational);
+    setState(d, Operational);
+
+    // Configure SDO client to this node
+    {
+        UNS8 nodeU8 = (UNS8)nodeId;
+        UNS32 cob_tx = 0x600 + (UNS32)nodeU8;
+        UNS32 cob_rx = 0x580 + (UNS32)nodeU8;
+        UNS32 sz32 = sizeof(UNS32);
+        UNS32 sz8  = sizeof(UNS8);
+        if (writeLocalDict(d, 0x1280, 1, &cob_tx, &sz32, RW) != OD_SUCCESSFUL)
+            fprintf(stderr, "Warn: failed to set 0x1280:1 (TX COB-ID)\n");
+        if (writeLocalDict(d, 0x1280, 2, &cob_rx, &sz32, RW) != OD_SUCCESSFUL)
+            fprintf(stderr, "Warn: failed to set 0x1280:2 (RX COB-ID)\n");
+        if (writeLocalDict(d, 0x1280, 3, &nodeU8, &sz8, RW) != OD_SUCCESSFUL)
+            fprintf(stderr, "Warn: failed to set 0x1280:3 (Server NodeID)\n");
+    }
+
+    masterSendNMTstateChange(d, (UNS8)nodeId, NMT_Start_Node);
+
+    unsigned sz = size_of_type(dtype);
+    if(sz == 0){ fprintf(stderr, "Unsupported type for write.\n"); canClose(d); return 3; }
+
+    // Prepare value container matching type
+    UNS8  v_u8;  UNS16 v_u16;  UNS32 v_u32;
+    INTEGER8 v_i8; INTEGER16 v_i16; INTEGER32 v_i32;
+    void* pData = NULL;
+    switch(dtype){
+        case uint8:  v_u8  = (UNS8)(sval & 0xFF); pData = &v_u8;  break;
+        case uint16: v_u16 = (UNS16)(sval & 0xFFFF); pData = &v_u16; break;
+        case uint32: v_u32 = (UNS32)(sval & 0xFFFFFFFFu); pData = &v_u32; break;
+        case int8:   v_i8  = (INTEGER8)(sval & 0xFF); pData = &v_i8;  break;
+        case int16:  v_i16 = (INTEGER16)(sval & 0xFFFF); pData = &v_i16; break;
+        case int32:  v_i32 = (INTEGER32)(sval & 0xFFFFFFFFu); pData = &v_i32; break;
+        default: break;
+    }
+
+    printf("Writing SDO 0x%04X:%02X to node %d on %s (type=%s)\n", index, sub, nodeId, ifname, argv[5]);
+
+    // Initiate SDO write
+    UNS8 ret = writeNetworkDict(d, (UNS8)nodeId, index, sub, sz, dtype, pData, 0);
+    if(ret){
+        fprintf(stderr, "writeNetworkDict failed: 0x%02X\n", ret);
+        canClose(d);
+        return 4;
+    }
+
+    // Wait for completion
+    int loops = 0;
+    while(g_run){
+        UNS32 abortCode = 0;
+        UNS8 st = getWriteResultNetworkDict(d, (UNS8)nodeId, &abortCode);
+        if(st == SDO_FINISHED){
+            switch(dtype){
+                case uint8:  printf("Wrote: 0x%02X (u8=%u)\n",  v_u8,  (unsigned)v_u8); break;
+                case uint16: printf("Wrote: 0x%04X (u16=%u)\n", v_u16, (unsigned)v_u16); break;
+                case uint32: printf("Wrote: 0x%08X (u32=%u)\n", v_u32, (unsigned)v_u32); break;
+                case int8:   printf("Wrote: 0x%02X (i8=%d)\n",  (unsigned)(UNS8)v_i8,  (int)v_i8); break;
+                case int16:  printf("Wrote: 0x%04X (i16=%d)\n", (unsigned)(UNS16)v_i16, (int)v_i16); break;
+                case int32:  printf("Wrote: 0x%08X (i32=%d)\n", (unsigned)v_i32, (int)v_i32); break;
+                default: break;
+            }
+            break;
+        } else if(st == SDO_ABORTED_RCV || st == SDO_ABORTED_INTERNAL){
+            fprintf(stderr, "SDO write aborted (st=0x%02X): 0x%08X\n", st, (unsigned)abortCode);
+            canClose(d);
+            return 5;
+        }
+        usleep(1000 * 10);
+        if(++loops > 1000){
+            fprintf(stderr, "Timeout waiting SDO write response\n");
+            canClose(d);
+            return 6;
+        }
+    }
+
+    canClose(d);
+    return 0;
+}

--- a/include/objdictdef.h
+++ b/include/objdictdef.h
@@ -94,12 +94,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 typedef struct td_subindex
 {
-    const UNS8              bAccessType;
-    const UNS8              bDataType; /* Defines of what datatype the entry is */
+    UNS8              bAccessType;
+    UNS8              bDataType; /* Defines of what datatype the entry is */
     UNS32             size;      /* The size (in Byte) of the variable */
     union {
         void*          pObject;   /* This is the pointer of the Variable */
-        const CONSTSTORE void* const pObjectConst;
+        const CONSTSTORE void* pObjectConst;
     };
 } subindex;
 
@@ -107,12 +107,12 @@ typedef struct td_subindex
  */
 typedef struct td_indextable
 {
-    const CONSTSTORE subindex* const  pSubindex;   /* Pointer to the subindex */
-    const UNS8   bSubCount;   /* the count of valid entries for this subindex
+    const CONSTSTORE subindex*  pSubindex;   /* Pointer to the subindex */
+    UNS8   bSubCount;   /* the count of valid entries for this subindex
                          * This count here defines how many memory has been
                          * allocated. this memory does not have to be used.
                          */
-    const UNS16   index;
+    UNS16   index;
 } indextable;
 
 /**


### PR DESCRIPTION
…kage export

Highlights:

Add option CANFESTIVAL_BUILD_SHARED (default ON) to switch between SHARED and STATIC libraries Use CANFESTIVAL_LIB_TYPE for canfestival and canfestival_can_socket targets Add GNUInstallDirs for standard install paths
Install libraries and example executables (ARCHIVE/LIBRARY/RUNTIME) Install public headers and object dictionary (OD) headers Add CMake package export:
Generate CanFestivalConfig.cmake / CanFestivalConfigVersion.cmake Export CanFestivalTargets.cmake with namespace CanFestival:: Set project version 1.0.0 and write version file
External usage: find_package(CanFestival REQUIRED) then link CanFestival::canfestaival / CanFestival::canfestival_can_socket Keep original compile options and defines
Usage:

Default shared: cmake -B build .
Static: cmake -B build -DCANFESTIVAL_BUILD_SHARED=OFF .
Install: cmake --build build && cmake --install build